### PR TITLE
[Bugfix] 프론트와 소캣 통신과 읽음처리를 위한 코드 수정

### DIFF
--- a/services/messageService.js
+++ b/services/messageService.js
@@ -2,8 +2,6 @@ const { ObjectId } = require('mongodb');
 const { getDb } = require('../db');
 
 const createMessage = async ({ chatId, senderId, content }) => {
-    console.log("messageService.createMessage 호출됨. content:", content); // 디버깅 로그 추가
-
     const db = getDb();
 
     // 채팅방이 존재하는지 확인


### PR DESCRIPTION

### 📌 작업 내용
-  메시지 송신(sendMessage) 이벤트 처리 방식: 이벤트 핸들러 매개변수로 단일 payload 객체를 받아, 내부에서 구조 분해. (원래는 이벤트 핸들러 매개변수를 함수 선언 시 바로 구조 분해하여 ({ chatId, senderId, content })로 받음)
메시지 생성 후, 백엔드에서 반환받은 newMessage 객체의 _id와 생성 시간을 사용하여 msgData를 구성(원래는 messageService.createMessage의 반환값을 따로 저장하지 않고, 단순히 새 메시지를 생성한 후 new Date()로 생성시간을 지정, _id 필드를 msgData에 포함x)

- 메시지 읽음(messagesRead) 이벤트 처리 : 클라이언트에서 받은 'messagesRead' 이벤트를 수신한 후, 해당 채팅방 전체로 'messagesRead' 이벤트를 emit ( 원래 없었음 )

### 🤔 이유 (선택 사항)
- 읽음 처리 기능과 소캣 통신 시 id 값들 받아오기 위함.

close #37 




